### PR TITLE
Fix the order of ARG in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.20
 
-ARG REVIEWDOG_VERSION=v0.17.4
 ARG TERRAFORM_VERSION=1.7.3
+ARG REVIEWDOG_VERSION=v0.17.4
 
 SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
 


### PR DESCRIPTION
https://github.com/reviewdog/action-terraform-validate/blob/main/action.yml#L38
Because the first argument is terraform version.