### PR TITLE
feat: tf token support

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -8,6 +8,9 @@ inputs:
   workdir:
     description: 'Working directory relative to the root directory.'
     default: '.'
+  terraform_cloud_token:
+    description: 'The terraform token for authentication with private registries.'
+    default: ''
   ### Flags for reviewdog ###
   level:
     description: 'Report level for reviewdog [info,warning,error]'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,6 +13,7 @@ wget -q https://releases.hashicorp.com/terraform/"${TERRAFORM_VERSION}"/terrafor
     && rm -rf ./terraform_"${TERRAFORM_VERSION}"_linux_amd64.zip
 
 export REVIEWDOG_GITHUB_API_TOKEN="${INPUT_GITHUB_TOKEN}"
+export TF_TOKEN_app_terraform_io="${INPUT_TERRAFORM_CLOUD_TOKEN}"
 
 jq_script='
 .diagnostics[]


### PR DESCRIPTION
This PR adds support for using this action for workspaces that have a dependency on Terraform Cloud (e.g. when using private modules or data sources from there).