### PR TITLE
Add `name` input to prevent reviewdog from overwriting comments from other runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,12 @@ inputs:
       Exit code for reviewdog when errors are found [true,false]
       Default is `false`.
     default: 'false'
+  name:
+    description: |
+      Tool name shown in review comment for reviewdog.
+      Also serves as an identifier to indicate which comments reviewdog should overwrite.
+      Useful in monorepos with multiple root modules where terraform validate needs to be run multiple times.
+    default: 'terraform validate'
   reviewdog_flags:
     description: 'Additional reviewdog flags'
     default: ''
@@ -48,6 +54,8 @@ inputs:
 ```
 
 ## Usage
+
+### For single root module
 
 ```yaml
 name: reviewdog
@@ -66,4 +74,32 @@ jobs:
           # Change reporter level if you need.
           # GitHub Status Check won't become failure with warning.
           level: warning
+```
+
+### For multiple root modules
+
+```yaml
+name: reviewdog
+on: [pull_request]
+jobs:
+  terraform_validate:
+    name: runner / terraform validate
+    strategy:
+      matrix:
+        root_module:
+          - development
+          - production
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: reviewdog/action-terraform-validate@v1
+        with:
+          github_token: ${{ secrets.github_token }}
+          # Change reviewdog reporter if you need [github-pr-check,github-check,github-pr-review].
+          reporter: github-pr-review
+          # Change reporter level if you need.
+          # GitHub Status Check won't become failure with warning.
+          level: warning
+          # Explicitly specify a unique name for each job to prevent reviewdog from overwriting comments across jobs.
+          name: terraform validate ${{ matrix.root_module }}
 ```

--- a/README.md
+++ b/README.md
@@ -95,11 +95,10 @@ jobs:
       - uses: reviewdog/action-terraform-validate@v1
         with:
           github_token: ${{ secrets.github_token }}
-          # Change reviewdog reporter if you need [github-pr-check,github-check,github-pr-review].
           reporter: github-pr-review
-          # Change reporter level if you need.
-          # GitHub Status Check won't become failure with warning.
           level: warning
+          # Explicitly specify a root module path for each job.
+          workdir: ./terraform/${{ matrix.root_module }}
           # Explicitly specify a unique name for each job to prevent reviewdog from overwriting comments across jobs.
           name: terraform validate ${{ matrix.root_module }}
 ```

--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ inputs:
   name:
     description: |
       Tool name shown in review comment for reviewdog.
-      Also serves as an identifier to indicate which comments reviewdog should overwrite.
-      Useful in monorepos with multiple root modules where terraform validate needs to be run multiple times.
+      Also acts as an identifier for determining which comments reviewdog should overwrite.
+      Useful in monorepos with multiple root modules where terraform validate needs to run multiple times.
     default: 'terraform validate'
   reviewdog_flags:
     description: 'Additional reviewdog flags'

--- a/action.yml
+++ b/action.yml
@@ -28,6 +28,12 @@ inputs:
       Exit code for reviewdog when errors are found [true,false]
       Default is `false`.
     default: 'false'
+  name:
+    description: |
+      Tool name shown in review comment for reviewdog.
+      Also serves as an identifier to indicate which comments reviewdog should overwrite.
+      Useful in monorepos with multiple root modules where terraform validate needs to be run multiple times.
+    default: 'terraform validate'
   reviewdog_flags:
     description: 'Additional reviewdog flags'
     default: ''

--- a/action.yml
+++ b/action.yml
@@ -31,8 +31,8 @@ inputs:
   name:
     description: |
       Tool name shown in review comment for reviewdog.
-      Also serves as an identifier to indicate which comments reviewdog should overwrite.
-      Useful in monorepos with multiple root modules where terraform validate needs to be run multiple times.
+      Also acts as an identifier for determining which comments reviewdog should overwrite.
+      Useful in monorepos with multiple root modules where terraform validate needs to run multiple times.
     default: 'terraform validate'
   reviewdog_flags:
     description: 'Additional reviewdog flags'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -34,7 +34,7 @@ terraform init -backend=false
 terraform validate -json \
   | jq "$jq_script" -c \
   | reviewdog -f="rdjsonl" \
-      -name="terraform validate" \
+      -name="${INPUT_NAME}" \
       -reporter="${INPUT_REPORTER:-github-pr-check}" \
       -filter-mode="${INPUT_FILTER_MODE}" \
       -fail-on-error="${INPUT_FAIL_ON_ERROR}" \


### PR DESCRIPTION
## Overview

This PR adds a new `name` input to the action, allowing users to specify a unique `-name` option for reviewdog.


## Details

### Problem

In reviewdog, the `-name` option is used to identify review comments. When multiple reviewdog runs use the same `-name`, they overwrite each other’s comments.

This behavior causes issues in monorepos containing multiple Terraform root modules, where `terraform validate` needs to be run separately for each module.

### Example Scenario

- Two Terraform root modules: `terraform/development` and `terraform/production`.
- Two separate GitHub Actions steps running `terraform validate` and reviewdog on each module using `reviewdog/action-terraform-validate`.
- Without a unique `-name`, the second step overwrites the comments from the first step.

Please refer to PR https://github.com/h-matsuo/action-terraform-validate/pull/1 for a concrete example demonstrating this issue.

### Solution

This PR introduces a `name` input parameter to the action, allowing users to specify a unique `-name` for each reviewdog run. By providing a unique `-name` for each run, review comments from different runs will not interfere with each other:

```yml
- uses: reviewdog/action-terraform-validate@v1
  with:
    name: terraform validate (development)
    workdir: terraform/development

- uses: reviewdog/action-terraform-validate@v1
  with:
    name: terraform validate (production)
    workdir: terraform/production
```

With this change, reviewdog will create separate sets of comments for each module, ensuring that all validation issues are reported correctly.

For a demonstration of the issue being resolved with this change, please see PR https://github.com/h-matsuo/action-terraform-validate/pull/2.