### PR TITLE
Support for `arm64` architecture

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,9 +8,17 @@ if [ -n "${GITHUB_WORKSPACE}" ] ; then
   git config --global --add safe.directory "${GITHUB_WORKSPACE}" || exit 1
 fi
 
-wget -q https://releases.hashicorp.com/terraform/"${TERRAFORM_VERSION}"/terraform_"${TERRAFORM_VERSION}"_linux_amd64.zip \
-    && unzip ./terraform_"${TERRAFORM_VERSION}"_linux_amd64.zip -d /usr/local/bin/ \
-    && rm -rf ./terraform_"${TERRAFORM_VERSION}"_linux_amd64.zip
+UNAME_ARCH="$(uname -m)"
+case "${UNAME_ARCH}" in
+  x86*)      ARCH=amd64;;
+  arm64)     ARCH=arm64;;
+  aarch64)   ARCH=arm64;;
+  *)         echo "Unsupported architecture: ${UNAME_ARCH}. Only AMD64 and ARM64 are supported by the action" && exit 1
+esac
+
+wget -q "https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_${ARCH}".zip \
+    && unzip "./terraform_${TERRAFORM_VERSION}_linux_${ARCH}.zip" -d /usr/local/bin/ \
+    && rm -rf "./terraform_${TERRAFORM_VERSION}_linux_${ARCH}.zip"
 
 export REVIEWDOG_GITHUB_API_TOKEN="${INPUT_GITHUB_TOKEN}"
 export TF_TOKEN_app_terraform_io="${INPUT_TERRAFORM_CLOUD_TOKEN}"


### PR DESCRIPTION
## Overview

This PR adds support for the `arm64` architecture, allowing users to use this action on ARM runners, such as [larger runners](https://docs.github.com/en/actions/using-github-hosted-runners/using-larger-runners) and [self-hosted runners](https://docs.github.com/en/actions/hosting-your-own-runners).

## Details

To enable `arm64` support, `entrypoint.sh` was modified to detect the runner's architecture and download the corresponding Terraform binary.

Additionally, following the approach used in https://github.com/reviewdog/action-trivy/pull/63, this update treats `aarch64` as equivalent to `arm64` for compatibility (see that PR for further details).